### PR TITLE
fix: update repoUrl project-wide  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center" style="margin-top: 12px">
   <a href="https://www.jargons.dev">
-    <img width="700" alt="jargons.dev" src="https://github.com/devjargons/jargons.dev/assets/25631971/5d1db25d-18e0-4544-ac98-9aa4e1097e14">
+    <img width="700" alt="jargons.dev" src="https://github.com/jargonsdev/jargons.dev/assets/25631971/5d1db25d-18e0-4544-ac98-9aa4e1097e14">
   </a>
   <h1><tt>jargons.dev</tt></h1>
   <h3>The Software Engineering Dictionary</h3>
@@ -33,7 +33,7 @@ To get set-up follow these steps:
 1. Clone the repository:
 
    ```sh
-   git clone https://github.com/devjargons/jargons.dev.git
+   git clone https://github.com/jargonsdev/jargons.dev.git
    ```
 
 2. Navigate to the project directory:

--- a/dev/setup.js
+++ b/dev/setup.js
@@ -6,7 +6,7 @@ import registerGitHubApp from "./lib/register-github-app/index.js";
 const appCredentials = await registerGitHubApp({
   // name of your app
   name: "jargons.dev-app-for-",
-  url: "https://github.com/devjargons/jargons.dev/CONTRIBUTING.md",
+  url: "https://github.com/jargonsdev/jargons.dev/CONTRIBUTING.md",
   default_permissions: {
     issues: "write",
   }

--- a/src/lib/submit-word.js
+++ b/src/lib/submit-word.js
@@ -4,7 +4,7 @@ import editWordPRTemp from "./templates/edit-word-pr.md.js";
 
 /**
  * Submit word - create a Pull Request to add word to project repository
- * @param {import("octokit").Octokit} devJargonsOctokit 
+ * @param {import("octokit").Octokit} jargonsdevOctokit 
  * @param {import("octokit").Octokit} userOctokit 
  * @param {"new" | "edit"} action 
  * @param {{ repoFullname: string, repoMainBranchRef: string }} projectRepoDetails 
@@ -13,7 +13,7 @@ import editWordPRTemp from "./templates/edit-word-pr.md.js";
  * 
  * @todo implement (submit as) `draft` feature - [idea]
  */
-export async function submitWord(devJargonsOctokit, userOctokit, action, projectRepoDetails, forkedRepoDetails, word) {
+export async function submitWord(jargonsdevOctokit, userOctokit, action, projectRepoDetails, forkedRepoDetails, word) {
   const { repoFullname, repoMainBranchRef } = projectRepoDetails;
   const { repoName, repoOwner } = getRepoParts(repoFullname);
   const { repoOwner: forkedRepoOwner } = getRepoParts(forkedRepoDetails.repoFullname);
@@ -38,8 +38,8 @@ export async function submitWord(devJargonsOctokit, userOctokit, action, project
     maintainers_can_modify: true
   });
 
-  // DevJargons (bot) App adds related labels to PR
-  await devJargonsOctokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/labels", {
+  // jargons-dev (bot) App adds related labels to PR
+  await jargonsdevOctokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/labels", {
     owner: repoOwner,
     repo: repoName,
     issue_number: response.data.number,

--- a/src/pages/api/dictionary.js
+++ b/src/pages/api/dictionary.js
@@ -38,7 +38,7 @@ export async function POST({ request, cookies }) {
   const metadata = JSON.parse(data.get("metadata"));
 
   const userOctokit = app.getUserOctokit({ token: accessToken.value });
-  const devJargonsOctokit = app.octokit;
+  const jargonsdevOctokit = app.octokit;
 
   // Fork repo
   const fork = await forkRepository(userOctokit, PROJECT_REPO_DETAILS);
@@ -87,7 +87,7 @@ export async function POST({ request, cookies }) {
 
     // submit the edit in new pr
     const wordSubmission = await submitWord(
-      devJargonsOctokit, 
+      jargonsdevOctokit, 
       userOctokit, 
       action, 
       PROJECT_REPO_DETAILS, 
@@ -147,7 +147,7 @@ export async function DELETE({ request, cookies }) {
   // const metadata = JSON.parse(data.get("metadata"));
 
   const userOctokit = app.getUserOctokit({ token: accessToken.value });
-  // const devJargonsOctokit = app.octokit;
+  // const jargonsdevOctokit = app.octokit;
 
   // Fork repo
   const fork = await forkRepository(userOctokit, PROJECT_REPO_DETAILS);


### PR DESCRIPTION
### Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->

This Pull Request updates all instance of old organization name in the repoUrl project-wide following the decision of change org name from `devjargons` to `jargonsdev`. 

#### Changes Made

- Updated giturl in README
- Updated project url to the Contribution guide in `dev/setup` script
- Factored in new name in function params in `submit-word` script and `dictionary` api handler, by updating `devJargonsOctokit` to `jargonsdevOctokit`

### Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->

NA

### Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->

NA

### Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->

NA
