### PR TITLE
fix(build): Move tailwindcss to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,13 +28,13 @@
         "octokit": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-markdown": "^9.0.1",
-        "tailwindcss": "^3.4.1"
+        "react-markdown": "^9.0.1"
       },
       "devDependencies": {
         "@octokit/request": "^9.1.1",
         "@tailwindcss/container-queries": "^0.1.1",
-        "@tailwindcss/typography": "^0.5.10"
+        "@tailwindcss/typography": "^0.5.10",
+        "tailwindcss": "^3.4.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "octokit": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-markdown": "^9.0.1",
-    "tailwindcss": "^3.4.1"
+    "react-markdown": "^9.0.1"
   },
   "devDependencies": {
     "@octokit/request": "^9.1.1",
     "@tailwindcss/container-queries": "^0.1.1",
-    "@tailwindcss/typography": "^0.5.10"
+    "@tailwindcss/typography": "^0.5.10",
+    "tailwindcss": "^3.4.1"
   }
 }


### PR DESCRIPTION
### Description
This PR moves TailwindCSS to the devDependencies.

### Related Issue
Fixes #19 