### PR TITLE
refactor(search): implement `normalizeAsUrl` for key computation

### DIFF
--- a/src/lib/stores/search.js
+++ b/src/lib/stores/search.js
@@ -1,4 +1,6 @@
 import { atom, map } from "nanostores";
+import { normalizeAsUrl } from "../utils/index.js";
+
 
 export const $isSearchOpen = atom(false);
 
@@ -20,8 +22,8 @@ export function $addToRecentSearchesFn({ word, url }) {
   const storedSearches = JSON.parse(localStorage.getItem("jargons.dev:recent_searches")) || {};
   $recentSearches.set({ ...storedSearches });
 
-  const lowercaseKey = word.toLowerCase();
-  const key = lowercaseKey.includes(" ") ? lowercaseKey.split(" ").join("-") : lowercaseKey;
+  const key = normalizeAsUrl(word);
+
 
   const recentSearchesCopy = $recentSearches.get();
 


### PR DESCRIPTION
### Description

Refactor $addToRecentSearchesFn to use normalizeAsUrl

### Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->

Fixes #48

### Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->



### Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->


