### PR TITLE
Auth feature - fourth iteration

### DIFF
--- a/src/components/islands/profile.jsx
+++ b/src/components/islands/profile.jsx
@@ -67,7 +67,7 @@ export default function Profile({ isAuthed, userData, authUrl }) {
 
           {/* Logout/Disconnect */}
           <div>
-            <a href="/logout" className="no-underline flex items-center space-x-2 px-5 py-2 hover:bg-red-100 hover:text-red-900">
+            <a href="/logout?return_to=/" className="no-underline flex items-center space-x-2 px-5 py-2 hover:bg-red-100 hover:text-red-900">
               <svg className="size-6" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
                 <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M20 12H8m12 0-4 4m4-4-4-4M9 4H7a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h2"/>
               </svg>

--- a/src/pages/logout.astro
+++ b/src/pages/logout.astro
@@ -1,8 +1,14 @@
 ---
-import doLogout from "../lib/actions/do-logout.js";
+import doAuth from "../lib/actions/do-auth.js";
 
 const { url: { searchParams }, redirect } = Astro;
 
-const { isLoggedOut } = await doLogout(Astro);
-if (isLoggedOut) return redirect(searchParams.get("return_to") || "/");
+const { isAuthed, getAuthUrl } = await doAuth(Astro);
+
+if (isAuthed) {
+  const { isLoggedOut } = await doAuth(Astro, { action: "logout" });
+  if (isLoggedOut) return redirect(searchParams.get("return_to") || "/");
+} else {
+  return redirect(getAuthUrl({ path: "/logout" }));
+}
 ---


### PR DESCRIPTION
Fixes #30

Implement the OAuth flow state object storage in cookies and the signout/disconnect feature.

* Store the OAuth flow state object in cookies in `src/lib/actions/do-auth.js` and compare it with the `state` param in the `doAuth` function.
* Retrieve the stored state from cookies in `src/pages/api/github/oauth/callback.js`, compare it with the `state` param, and delete the stored state from cookies after comparison.
* Update the signout/disconnect link in `src/components/islands/profile.jsx` to point to the new signout route.
* Update the signout logic in `src/pages/logout.astro` to use the new signout function from `doAuth`.
