### PR TITLE
fix(search): change overflow-y-scroll to overflow-y-auto in SearchResult component

### DIFF
--- a/src/components/islands/search.jsx
+++ b/src/components/islands/search.jsx
@@ -222,7 +222,7 @@ function SearchResult({ result = [], cursor, searchTerm }) {
   const router = useRouter();
 
   return (
-    <div className="block w-full text-sm md:text-base overflow-y-scroll scrollbar">
+    <div className="block w-full text-sm md:text-base overflow-y-auto scrollbar">
       {result.length < 1 && searchTerm.length >= 1 ? (
         /**
          * @todo add message suggesting adding/contributing the word to dictionary


### PR DESCRIPTION
### Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->
This PR replaces overflow-y-scroll with overflow-y-auto in SearchResult component


### Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->
Fixes #136 


### Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->
![Runner H _ H AI and 4 more pages - Personal 2 - Microsoft​ Edge 7_6_2025 6_02_19 AM](https://github.com/user-attachments/assets/f049d409-449d-4224-aaab-4a01fb313ace)



### Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->


