### PR TITLE
fix: update word filtering and path generation in browse page

### DIFF
--- a/src/pages/browse/[alpha]/[page].astro
+++ b/src/pages/browse/[alpha]/[page].astro
@@ -4,8 +4,8 @@ import { ALPHABETS } from "../../../../constants.js";
 import BaseLayout from "../../../layouts/base.astro";
 import Navbar from "../../../components/navbar.astro";
 import Search from "../../../components/islands/search";
-import { buildWordPathname } from "../../../lib/utils/index.js";
 import ContributionCTA from "../../../components/contribution-cta.astro";
+import { buildWordPathname, buildWordSlug } from "../../../lib/utils/index.js";
 
 const { page } = Astro.props;
 const params = Astro.params;
@@ -17,8 +17,7 @@ export const prerender = true;
 export async function getStaticPaths({ paginate }) {
   const dictionary = await getCollection("dictionary");
   return ALPHABETS.flatMap(alpha => {
-    // @ts-expect-error - `slug` property is not defined in `CollectionEntry` type - see https://github.com/withastro/astro/issues/14070
-    const filteredWords = dictionary.filter(word => word.slug[0] === alpha);
+    const filteredWords = dictionary.filter(word => word.id[0] === alpha);
     return paginate(filteredWords, {
       params: { alpha },
       // pageSize: 1
@@ -45,7 +44,7 @@ export async function getStaticPaths({ paginate }) {
     <!-- Words List -->
     <div>
       {page.data.length ? page.data.map(word => (
-        <a href={buildWordPathname(word.slug)}
+        <a href={buildWordPathname(buildWordSlug(word.id))}
           class="flex items-center md:text-lg justify-between no-underline w-full p-4 even:bg-gray-100 hover:bg-gray-100/50"
         >
           <span>{ word.data.title }</span>


### PR DESCRIPTION
### Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->

This pull request updates the logic for browsing dictionary words by alphabet to use the `id` property instead of the deprecated `slug` property, and introduces a new utility function for building word slugs. The changes improve type safety and future-proof the code against upstream type changes.

**Refactoring for type safety and future compatibility:**

* Updated the filtering logic in `getStaticPaths` to use `word.id[0]` instead of `word.slug[0]`, addressing a TypeScript type issue and aligning with the latest data structure. ([src/pages/browse/[alpha]/[page].astroL20-R20](diffhunk://#diff-c87fe48708b5daee9f4aa138cb2970623ed74a334fa0912fef67f3a71905ee39L20-R20))
* Changed the word link rendering to use `buildWordSlug(word.id)` in combination with `buildWordPathname`, ensuring consistent slug generation from the new `id` property. ([src/pages/browse/[alpha]/[page].astroL48-R47](diffhunk://#diff-c87fe48708b5daee9f4aa138cb2970623ed74a334fa0912fef67f3a71905ee39L48-R47))
* Imported the new `buildWordSlug` utility from `lib/utils/index.js` to support the updated slug-building logic. ([src/pages/browse/[alpha]/[page].astroL7-R8](diffhunk://#diff-c87fe48708b5daee9f4aa138cb2970623ed74a334fa0912fef67f3a71905ee39L7-R8))

