### PR TITLE
refactor(editor): replace gh-search-api consumtion with graphql in jargons editor

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -3,6 +3,12 @@ export const PROJECT_REPO_DETAILS = {
   repoMainBranchRef: import.meta.env.PUBLIC_PROJECT_REPO_BRANCH_REF
 }
 
+export const LABELS = {
+  NEW_WORD: "📖new-word",
+  EDIT_WORD: "📖edit-word",
+  VIA_EDITOR: "💻via-jargons-editor",
+};
+
 export const SITE_META_DESCRIPTION = "A community-driven dictionary that simplifies software, engineering and tech terms for all levels. Curated by contributors, jargons.dev offers clear, easy-to-understand definitions."
 
 export const SITE_META_KEYWORDS = [  

--- a/src/lib/actions/do-contribution-stats.js
+++ b/src/lib/actions/do-contribution-stats.js
@@ -37,9 +37,9 @@ export default async function doContributionStats(astroGlobal) {
         pendingOpen: search(query: $pendingOpenQuery, type: ISSUE, first: 1) { issueCount }
       }
   `, {
-    "newMergedQuery": newMergedQuery,
-    "editMergedQuery": editMergedQuery,
-    "pendingOpenQuery": pendingOpenQuery,
+    newMergedQuery,
+    editMergedQuery,
+    pendingOpenQuery,
   });
 
   const newCount = data?.newMerged?.issueCount ?? 0;

--- a/src/lib/actions/do-contribution-stats.js
+++ b/src/lib/actions/do-contribution-stats.js
@@ -1,7 +1,7 @@
 import app from "../octokit/app.js";
 import { decrypt } from "../utils/crypto.js";
 import { buildStatsUrl } from "../utils/index.js";
-import { PROJECT_REPO_DETAILS } from "../../../constants.js";
+import { PROJECT_REPO_DETAILS, LABELS } from "../../../constants.js";
 
 /**
  * Get some jargons contribution stats for current user on the Jargons Editor
@@ -16,49 +16,56 @@ export default async function doContributionStats(astroGlobal) {
   });
   const userOctokit = app.getUserOctokit({ token: accessToken.value });
 
-  /**
-   * @todo Implement narrowed search to project's main branch
-   */
-  const baseQuery = `repo:${repoFullname} is:pull-request type:pr author:@me`;
-  const baseStatsUrlQuery = `is:pr author:@me`;
+  // Build queries using the viewer's login and narrow to main branch if available
+  const { data: me } = await userOctokit.request("GET /user");
+  const viewerLogin = me?.login;
 
-  /**
-   * @todo [thoughts]: would be nice to have all these requests in one, and use a filter to separate by labels
-   * [potential bottleneck]: no way to know whether a PR is "merged" considering that "closed" doesn't mean merged
-   */
-  const { data: newType } = await userOctokit.request("GET /search/issues", {
-    q: `${baseQuery} label:":book: new word" is:merged is:closed`,
+  const branchInfo = repoMainBranchRef ? repoMainBranchRef.split("/").slice(2).join("/") : "";
+
+  const baseQuery = `repo:${repoFullname} is:pull-request type:pr author:${viewerLogin} base:${branchInfo}`;
+  const baseStatsUrlQuery = `is:pr author:@me base:${branchInfo}`;
+
+  const newMergedQuery = `${baseQuery} label:"${LABELS.NEW_WORD}" is:merged is:closed`;
+  const editMergedQuery = `${baseQuery} label:"${LABELS.EDIT_WORD}" is:merged is:closed`;
+  const pendingOpenQuery = `${baseQuery} label:"${LABELS.VIA_EDITOR}" is:open`;
+
+  const data = await userOctokit.graphql(`
+    #graphql
+      query ContributionStats($newMergedQuery: String!, $editMergedQuery: String!, $pendingOpenQuery: String!) {
+        newMerged: search(query: $newMergedQuery, type: ISSUE, first: 1) { issueCount }
+        editMerged: search(query: $editMergedQuery, type: ISSUE, first: 1) { issueCount }
+        pendingOpen: search(query: $pendingOpenQuery, type: ISSUE, first: 1) { issueCount }
+      }
+  `, {
+    "newMergedQuery": newMergedQuery,
+    "editMergedQuery": editMergedQuery,
+    "pendingOpenQuery": pendingOpenQuery,
   });
-  const { data: editType } = await userOctokit.request("GET /search/issues", {
-    q: `${baseQuery} label:":book: edit word" is:merged is:closed`,
-  });
-  const { data: pendingType } = await userOctokit.request(
-    "GET /search/issues",
-    {
-      q: `${baseQuery} label:":book: edit word",":book: new word" is:unmerged is:open`,
-    }
-  );
+
+  const newCount = data?.newMerged?.issueCount ?? 0;
+  const editCount = data?.editMerged?.issueCount ?? 0;
+  const pendingCount = data?.pendingOpen?.issueCount ?? 0;
 
   return {
     newWords: {
-      count: newType.total_count,
+      count: newCount,
       url: buildStatsUrl(
         repoFullname,
-        `${baseStatsUrlQuery} is:merged is:closed label:":book: new word"`
+        `${baseStatsUrlQuery} is:merged is:closed label:"${LABELS.NEW_WORD}"`
       ),
     },
     editedWords: {
-      count: editType.total_count,
+      count: editCount,
       url: buildStatsUrl(
         repoFullname,
-        `${baseStatsUrlQuery} is:merged is:closed label:":book: edit word"`
+        `${baseStatsUrlQuery} is:merged is:closed label:"${LABELS.EDIT_WORD}"`
       ),
     },
     pendingWords: {
-      count: pendingType.total_count,
+      count: pendingCount,
       url: buildStatsUrl(
         repoFullname,
-        `${baseStatsUrlQuery} is:unmerged is:open`
+        `${baseStatsUrlQuery} is:open label:"${LABELS.VIA_EDITOR}"`
       ),
     },
   };

--- a/src/lib/submit-word.js
+++ b/src/lib/submit-word.js
@@ -1,3 +1,4 @@
+import { LABELS } from "../../constants.js";
 import { getRepoParts } from "./utils/index.js";
 import newWordPRTemp from "./templates/new-word-pr.md.js";
 import editWordPRTemp from "./templates/edit-word-pr.md.js";
@@ -44,8 +45,8 @@ export async function submitWord(jargonsdevOctokit, userOctokit, action, project
     repo: repoName,
     issue_number: response.data.number,
     labels: [
-      `:book: ${action} word`,
-      ":computer: via jargons-editor"
+      action === "new" ? LABELS.NEW_WORD : LABELS.EDIT_WORD,
+      LABELS.VIA_EDITOR
     ]
   });
 

--- a/src/pages/editor/index.astro
+++ b/src/pages/editor/index.astro
@@ -5,7 +5,7 @@ import doAuth from "../../lib/actions/do-auth.js";
 import Navbar from "../../components/navbar.astro";
 import { buildStatsUrl } from "../../lib/utils/index.js";
 import Profile from "../../components/islands/profile.jsx";
-import { PROJECT_REPO_DETAILS } from "../../../constants.js";
+import { PROJECT_REPO_DETAILS, LABELS } from "../../../constants.js";
 import doContributionStats from "../../lib/actions/do-contribution-stats.js";
 import ContributionCTA from "../../components/contribution-cta.astro";
 
@@ -18,8 +18,8 @@ const { newWords, editedWords, pendingWords } = await doContributionStats(Astro)
 const totalWords = {
   count: newWords.count + editedWords.count,
   url: buildStatsUrl(
-    PROJECT_REPO_DETAILS.repoFullname, 
-    `label:":book: edit word",":book: new word" is:pr is:closed is:merged author:@me`
+    PROJECT_REPO_DETAILS.repoFullname,
+    `(label:"${LABELS.EDIT_WORD}" OR label:"${LABELS.NEW_WORD}") is:pr is:closed is:merged author:@me`
   )
 }
 ---


### PR DESCRIPTION
### Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->

This pull request improves the way contribution stats are queried by switching to a single GraphQL request from github search-api which is getting removed after getting deprecated and narrowing results to the main branch. These changes enhance maintainability, accuracy, and future extensibility.
 introduces a standardized set of label constants for contribution-related pull requests and refactors the codebase to use these constants consistently. 

**Label standardization and usage:**

* Added a `LABELS` constant to `constants.js` to centralize label definitions for new words, edited words, and editor-originated contributions.
* Refactored label usage in `submitWord` to use the new constants instead of hardcoded strings. [[1]](diffhunk://#diff-da5c3e61f828ff6207118ba3e3196d6263237671b3897650d8642fa5576a00c6R1) [[2]](diffhunk://#diff-da5c3e61f828ff6207118ba3e3196d6263237671b3897650d8642fa5576a00c6L47-R49)

**Contribution stats improvements:**

* Refactored `doContributionStats` to use a single GraphQL query for all stats, improving performance and maintainability.
* Updated contribution stats queries to use the main branch and the standardized labels, ensuring more accurate results.

**Code consistency:**

* Updated imports in relevant files (`do-contribution-stats.js`, `submit-word.js`, `index.astro`) to use the new `LABELS` constant. [[1]](diffhunk://#diff-66fb997961c22f18ff765f0e831b43870a845fe98eadf9d176e26288f677a4ddL4-R4) [[2]](diffhunk://#diff-da5c3e61f828ff6207118ba3e3196d6263237671b3897650d8642fa5576a00c6R1) [[3]](diffhunk://#diff-19c5ae8617d4b91be3692fd77b705dd7e871e0b6750543a0d3a78293582cee4bL8-R8)
* Updated the total words stats query in `index.astro` to use the standardized labels and improved query syntax.

### Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->

Nil

### Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/27902060-d20e-4054-8314-7cb3756687e2" />

### Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->

Nil
