### PR TITLE
fix: add CI support to vector store (qdrant) cluster ping workflow

### DIFF
--- a/.github/workflows/ping-qdrant.yml
+++ b/.github/workflows/ping-qdrant.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
-        run: npm run ping:qdrant
+        run: npm run ping:qdrant:ci
 
       - name: Ping successful
         run: echo "✅ Qdrant cluster ping completed successfully"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:coverage": "vitest run --coverage",
     "setup": "node dev/setup.js",
     "seed:jai": "node --env-file=.env dev/seed-vector-store.js",
-    "ping:qdrant": "node --env-file=.env dev/ping-qdrant-cluster.js"
+    "ping:qdrant": "node --env-file=.env dev/ping-qdrant-cluster.js",
+    "ping:qdrant:ci": "node dev/ping-qdrant-cluster.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->

This pull request updates the Qdrant cluster ping workflow to better support CI environments. The main changes involve separating the Qdrant ping command for local and CI usage, and updating the workflow to use the new CI-specific command.

**Workflow improvements:**

* [`.github/workflows/ping-qdrant.yml`](diffhunk://#diff-9ebafec44c822f0cfbb1472b7953ce1fc9d5893a3ada2e964c67f5f5d961063cL32-R32): Changed the workflow to run `npm run ping:qdrant:ci` instead of `npm run ping:qdrant`, ensuring the correct environment variables are used for CI.

**Script and command updates:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R22): Added a new `ping:qdrant:ci` script that runs the ping without requiring local `.env` variables, and retained the original `ping:qdrant` script for local use.

## Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->

- #192 
- Follow-up to #193 

## Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->

NA

## Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->

- Modified GitHub Action Workflow