### PR TITLE
Dictionary (New Word): OSPO

### DIFF
--- a/src/content/dictionary/ospo.mdx
+++ b/src/content/dictionary/ospo.mdx
@@ -1,0 +1,11 @@
+---
+layout: ../../layouts/word.astro
+title: "OSPO"
+---
+OSPO (short for **Open Source Program Office**) is a dedicated team or function within an organization that manages its open source strategy, policies, and community engagement.
+
+An OSPO ensures that the organization uses, contributes to, and releases open source software in a structured and compliant way. It often handles licensing, governance, security practices, and collaboration with external open source communities, helping companies maximize the benefits of open source while minimizing risks.
+
+**Example**
+
+* A company’s OSPO sets guidelines for developers to contribute to open source projects responsibly and ensures compliance with licensing requirements.


### PR DESCRIPTION
# Word

#### OSPO

# Meaning/Definition

OSPO (short for **Open Source Program Office**) is a dedicated team or function within an organization that manages its open source strategy, policies, and community engagement.

An OSPO ensures that the organization uses, contributes to, and releases open source software in a structured and compliant way. It often handles licensing, governance, security practices, and collaboration with external open source communities, helping companies maximize the benefits of open source while minimizing risks.

**Example**

* A company’s OSPO sets guidelines for developers to contribute to open source projects responsibly and ensures compliance with licensing requirements.
