### PR TITLE
doc(apps/jai): correct `jAIPrompt` to `jAIPrompts` in readme

### DIFF
--- a/apps/jai/README.md
+++ b/apps/jai/README.md
@@ -50,7 +50,7 @@ apps/jai/
 Main module interface that exports all ✨jAI utilities:
 
 ```javascript
-export { jAIPrompt, formatMessage, model, vectorStore };
+export { jAIPrompts, formatMessage, model, vectorStore };
 ```
 
 #### `lib/jai-prompts.js`
@@ -148,7 +148,7 @@ Dedicated endpoint for AI-powered word definitions that:
 
 <!-- ### 3. Follow-up Chat API (`src/pages/api/jai/follow-up-chat.js`)
 
-Imports all four core utilities (`jAIPrompt`, `model`, `formatMessage`, `vectorStore`) for real-time AI interactions. Powers the follow-up chat feature with semantic search for relevant context, conversation history management, and streaming AI response generation. -->
+Imports all four core utilities (`jAIPrompts`, `model`, `formatMessage`, `vectorStore`) for real-time AI interactions. Powers the follow-up chat feature with semantic search for relevant context, conversation history management, and streaming AI response generation. -->
 
 ### Integration Flow
 


### PR DESCRIPTION
## Description
This fixes  inconsistencies where jAIPrompt (singular) is referenced instead of the correct jAIPrompts (plural) as used in the actual code implementation.


## Related Issue
Fixes #205 


## Screenshots/Screencasts
<img width="742" height="126" alt="image" src="https://github.com/user-attachments/assets/f75334a7-9e05-4c80-9ffe-7508453137ac" />



## Used feature 
search and replace 

