### PR TITLE
Update navbar.astro

### DIFF
--- a/src/components/navbar.astro
+++ b/src/components/navbar.astro
@@ -29,7 +29,9 @@ const { returnNav = { label: "Back", location: "../" } } = Astro.props;
         {returnNav.label}
       </span>
     </a>
-    <JargonsdevLogo class="drop-shadow drop-shadow-color-black h-10 md:h-12" />
+      <a href="/" class="block">
+    <JargonsdevLogo class="drop-shadow drop-shadow-color-black h-10 w-12"/>
+</a>
   </div>
   <slot />
 </nav>


### PR DESCRIPTION
## Description
This Pull Request implements the homepage navigation link for the Jargons.dev logo in the header. This follows standard web conventions, allowing users to return to the root page from anywhere on the site, thereby improving general user experiencefix(logo): Add homepage link to the Logo component #200



## Related Issue
Fixes #200


## Screenshots/Screencasts
before and after image of code is uploded



## Notes to Reviewer
The required link was implemented in src/components/navbar.astro. I wrapped the existing <JargonsdevLogo> component with an anchor tag (<a>) set to the site root (href="/"). No new npm
![image (1)](https://github.com/user-attachments/assets/71c4851b-6f98-43cd-bf48-16f11e270e1d)

