### PR TITLE
doc(contribution-guide): add guidelines for issues closed to community pickup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ Some issues are intentionally not open for general contributor assignment:
 - `wontfix`: We are not taking action on this (currently or possibly ever) due to priority, scope, strategy, or technical constraints. Constructive discussion is welcome, but please do not submit a PR “just fixing it” while this label remains.
 
 Guidelines:
+
 1. If an issue has one of the above labels, treat it as unavailable even if it is unassigned.
 2. You may (once) ask politely for clarification if the rationale isn’t clear—keep it concise and respectful.
 3. If you think there is a smaller or alternative angle worth exploring, open a new issue or discussion rather than overriding the label.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,18 @@ If you wish to work on an open issue, please ask for it to be assigned to you an
 
 In case you get stuck while working on an issue you've been assigned, feel free to ask question openly in the comment.
 
+#### Labels Closed to Community Pickup
+
+Some issues are intentionally not open for general contributor assignment:
+
+- `maintainers-only`: Requires core team context, elevated permissions (infra, secrets, deployment), or involves architectural refactors in progress. Do not ask to be assigned or open a PR unless a maintainer explicitly invites help.
+- `wontfix`: We are not taking action on this (currently or possibly ever) due to priority, scope, strategy, or technical constraints. Constructive discussion is welcome, but please do not submit a PR “just fixing it” while this label remains.
+
+Guidelines:
+1. If an issue has one of the above labels, treat it as unavailable even if it is unassigned.
+2. You may (once) ask politely for clarification if the rationale isn’t clear—keep it concise and respectful.
+3. If you think there is a smaller or alternative angle worth exploring, open a new issue or discussion rather than overriding the label.
+
 Please follow our [Code of Conduct](./code-of-conduct.md) in all your interactions with the project and its contributors.
 
 ### Pull Requests (PR)


### PR DESCRIPTION
## Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->

This pull request updates the `CONTRIBUTING.md` file to clarify which issues are not open for community assignment and adds guidelines for interacting with such issues. The goal is to help contributors understand when they should not request assignment or submit pull requests for certain labeled issues.

**Updates to issue assignment guidelines:**

* Added a new section describing the `maintainers-only` and `wontfix` labels, explaining that issues with these labels are not open for general contributor assignment and specifying the reasons behind these restrictions.
* Provided clear guidelines on how to interact with issues labeled as unavailable, including advice on asking for clarification and suggesting alternative approaches.

## Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->

NA

## Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->

NA

## Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->

NA
