### PR TITLE
fix:error typo (occured) correction

### DIFF
--- a/apps/jai/components/word-search.jsx
+++ b/apps/jai/components/word-search.jsx
@@ -75,7 +75,7 @@ export default function JAIWordSearch({ word }) {
             />
           </svg>
           <p className="font-medium text-red-800">
-            An Error Occured while generating the definition for{" "}
+            An Error Occurred while generating the definition for{" "}
             <span className="font-bold">{word}</span>.
           </p>
         </div>


### PR DESCRIPTION
## Description
This PR fixes a spelling error in the error message shown by the JAI Word Search component. The word "Occured" was corrected to "Occurred".

## Related Issue
Fixes #208 

## Screenshots/Screencasts
<img width="536" height="95" alt="Screenshot from 2025-10-01 23-32-07" src="https://github.com/user-attachments/assets/d87e956c-5bbb-4f05-8b89-4861f4a05ee7" />

<img width="562" height="111" alt="Screenshot from 2025-10-01 23-32-21" src="https://github.com/user-attachments/assets/622e3abb-52cf-452e-a8a3-8567fde85c8f" />

## Notes to Reviewer
No new npm packages added. This is a simple typo fix in the error message.

