### PR TITLE
docs(word-editor): update jsdoc types in `useWordEditor` hook

### DIFF
--- a/src/lib/hooks/use-word-editor.js
+++ b/src/lib/hooks/use-word-editor.js
@@ -3,7 +3,7 @@ import { $wordEditor } from "../stores/dictionary.js";
 
 /**
  * Custom hook serves as wrapper around `wordEditor` map store
- * @returns {{ title: string, content: string, setTitle: (title: string) => void, setContent: (content: string) => void }}
+ * * @returns {{ title: string, content: string, initialContent: string, setTitle: (title: string) => void, setContent: (content: string) => void, setInitialContent: (content: string) => void }}
  */
 export default function useWordEditor() {
   const word = useStore($wordEditor);

--- a/src/lib/hooks/use-word-editor.js
+++ b/src/lib/hooks/use-word-editor.js
@@ -3,7 +3,7 @@ import { $wordEditor } from "../stores/dictionary.js";
 
 /**
  * Custom hook serves as wrapper around `wordEditor` map store
- * * @returns {{ title: string, content: string, initialContent: string, setTitle: (title: string) => void, setContent: (content: string) => void, setInitialContent: (content: string) => void }}
+ * @returns {{ title: string, content: string, initialContent: string, setTitle: (title: string) => void, setContent: (content: string) => void, setInitialContent: (content: string) => void }}
  */
 export default function useWordEditor() {
   const word = useStore($wordEditor);


### PR DESCRIPTION
## Description
<!-- Please add PR description (don't leave blank) - example: This PR [adds/removes/fixes/replaces] the [feature/bug/etc] -->

This PR updates replaces the Jsdoc types in `useWordEditor` hook, making it easier for developers understand the hook's API. 


## Related Issue
<!-- Please prefix the issue number with Fixes/Resolves - example: Fixes #123 or Resolves #123 -->
Fixes #201 


## Screenshots/Screencasts
<!-- Please provide screenshots or video recording that demos your changes (especially if it's a visual change) -->

N/A

## Notes to Reviewer
<!-- Please state here if you added a new npm packages, or any extra information that can help reviewer better review you changes -->

This is my first contribution to this project(and my first PR for this year's Hacktoberfest), so any feedback is appreciated! :) 