### PR TITLE
docs(search): add JSDoc header to search.jsx (#216)

### DIFF
--- a/src/components/islands/search.jsx
+++ b/src/components/islands/search.jsx
@@ -1,3 +1,13 @@
+/**
+ * Search Component - Dictionary Search Interface with Keyboard Navigation
+ *
+ * @exports Search - Main search component with FlexSearch integration, modal state, and dictionary indexing
+ * @exports SearchTrigger - Trigger button/input with responsive variants and keyboard shortcut hints
+ * @exports SearchDialog - Modal search interface with input field, keyboard navigation, and live results
+ * @exports SearchInfo - Default placeholder component when no input is provided
+ * @exports SearchResult - Search results list with cursor navigation and jAI fallback
+ */
+
 import { buildWordPathname, buildWordSlug } from "../../lib/utils/index.js";
 import Flexsearch from "flexsearch";
 import { useEffect, useState } from "react";
@@ -19,8 +29,15 @@ const searchIndex = new Flexsearch.Document({
 });
 
 /**
- * Search Component Island
- * @param {{ triggerSize: "sm" | "md", dictionary: MarkdownInstance<Record<string, any>>[] }} props
+ * Main Search Component Island
+ * Integrates FlexSearch indexing with dictionary entries,
+ * controls modal state, and renders trigger + dialog.
+ *
+ * @component
+ * @param {Object} props
+ * @param {"sm" | "md"} props.triggerSize - Size of the search trigger
+ * @param {MarkdownInstance<Record<string, any>>[]} props.dictionary - Words to index and search
+ * @returns {JSX.Element}
  */
 export default function Search({ triggerSize, dictionary }) {
   const isSearchOpen = useStore($isSearchOpen);
@@ -46,8 +63,15 @@ export default function Search({ triggerSize, dictionary }) {
 }
 
 /**
- * Search Trigger
- * @param {{size: "sm" | "md"}} props
+ * Search Trigger Component
+ *
+ * Responsive trigger button/input that opens the search dialog.
+ * Displays keyboard shortcut hint (Ctrl+K or ⌘K).
+ *
+ * @component
+ * @param {Object} props
+ * @param {"sm" | "md"} [props.size="md"] - Trigger size variant
+ * @returns {JSX.Element}
  */
 function SearchTrigger({ size = "md" }) {
   const isSearchOpen = useStore($isSearchOpen);
@@ -153,9 +177,16 @@ function SearchTrigger({ size = "md" }) {
 }
 
 /**
- * Search Dialog
- * @todo implement search term debouncing
- * @todo implement visual que buttons (↑ ↓ ↵) for keyboard navigation on search dialog component
+ * Search Dialog Component
+ *
+ * Full-screen modal interface with search input,
+ * FlexSearch results, AI fallback, and keyboard navigation.
+ *
+ * @component
+ * @returns {JSX.Element}
+ *
+ * @todo Implement search term debouncing
+ * @todo Implement visual que buttons (↑ ↓ ↵) for keyboard navigation on search dialog component
  */
 function SearchDialog() {
   useLockBody();
@@ -279,8 +310,14 @@ function SearchDialog() {
 }
 
 /**
- * Default Search Text Placeholder
- * @todo implement recent search term list
+ * Search Info Component
+ *
+ * Placeholder text shown when no search term is entered.
+ *
+ * @component
+ * @returns {JSX.Element}
+ *
+ * @todo Implement recent search term list
  */
 const SearchInfo = () => (
   <p className="block w-full text-sm md:text-base px-2 py-1 md:px-4 md:py-2 text-slate-500 font-normal leading-6">
@@ -289,8 +326,17 @@ const SearchInfo = () => (
 );
 
 /**
- * Search result
- * @param {{ result: Array<{ id: number, doc: { title: string, slug: string }, searchTerm: string }> }} props
+ * Search Result Component
+ *
+ * Displays FlexSearch results or jAI fallback when no matches are found.
+ * Supports cursor-based keyboard navigation.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Array<{ id: number, doc: { title: string, slug: string } }>} props.result - Search results
+ * @param {number} props.cursor - Current cursor index for keyboard navigation
+ * @param {string} props.searchTerm - Current search input
+ * @returns {JSX.Element}
  */
 function SearchResult({ result = [], cursor, searchTerm }) {
   const router = useRouter();


### PR DESCRIPTION

  ## Description
  This PR adds JSDoc headers to the search.jsx component and its sub-components to improve code documentation
  and developer experience.

  ## Related Issue
  Fixes #216