### PR TITLE
fix(api/jai/search): ensure CORS headers on all responses, add OPTION…

### DIFF
--- a/src/pages/api/jai/search.js
+++ b/src/pages/api/jai/search.js
@@ -3,6 +3,16 @@ import { RunnableSequence } from "@langchain/core/runnables";
 import { jAIPrompts, model } from "../../../../apps/jai/index.js";
 import { HttpResponseOutputParser } from "langchain/output_parsers";
 
+export async function OPTIONS() {
+  const corsHeaders = {
+    "Access-Control-Allow-Origin": "same-origin",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+
+  return new Response(null, { status: 204, headers: corsHeaders });
+}
+
 export async function POST({ request }) {
   const corsHeaders = {
     "Access-Control-Allow-Origin": "same-origin",
@@ -13,6 +23,13 @@ export async function POST({ request }) {
   try {
     // Extract the `messages` from the body of the request
     const { messages } = await request.json();
+
+    if (!messages || !Array.isArray(messages)) {
+      return Response.json(
+        { error: "Invalid request body" },
+        { status: 400, headers: corsHeaders },
+      );
+    }
 
     const currentMessageContent = messages[messages.length - 1].content;
 


### PR DESCRIPTION
## Description
This PR improves CORS handling in 'src/pages/api/jai/search.js'.

Changes made:
1. Added an OPTIONS handler to properly respond to preflight requests with the required CORS headers.
2. Added early-return validation for invalid request bodies (messages missing / not an array) and ensured those responses also include CORS headers.
3. Ensured consistency so that all responses (including errors) return the defined CORS headers.

## Related Issue
Fixes #218 

## Screenshots/Screencasts
Early check for invalid request
<img width="2725" height="470" alt="Screenshot 2025-10-02 152639" src="https://github.com/user-attachments/assets/16e0ee1d-136b-4147-98b7-e5ec79796548" />

OPTIONS handler to respond to preflight requests
<img width="2731" height="618" alt="Screenshot 2025-10-02 152733" src="https://github.com/user-attachments/assets/a0c709c2-e398-4bc4-9e09-97e391ee8a1a" />

Result with normal free tier OpenAI API key
<img width="1732" height="970" alt="image" src="https://github.com/user-attachments/assets/f7f2e478-0246-4a5f-91f0-4ea393a87104" />

Result using mock openAI response
<img width="1738" height="1072" alt="image" src="https://github.com/user-attachments/assets/0504660e-fa4f-43a5-ba15-e85b0991978f" />


## Notes to Reviewer
Since this endpoint depends on the OpenAI API, running tests locally requires a paid API key. Without credits, requests return 429 Too Many Requests, so I’m unable to fully validate the end-to-end behavior. However, using mock OpenAI response the CORS headers are being included, as shown in screenshots.
For now, I’ve focused on structural improvements: adding OPTIONS preflight support and early pre-checks for invalid input with proper CORS headers.
Please advise on the best way to test these CORS updates under this limitation? Is there a recommended approach to mock the OpenAI response for testing?
